### PR TITLE
Fix out-of-range indices for Shortest master with multivariate signals

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -33,7 +33,7 @@ Internal method that computes aligning indices.
 """
 function compute_aligning_indices(s, method::Delay; master)
     sm = get_master(master, s)
-    inds = [1:lastlength(s) for s in s]
+    inds = [1:lastlength(si) for si in s]
     # find delays to align with master
     d = map(s) do si
         si === sm && (return 0)
@@ -42,16 +42,16 @@ function compute_aligning_indices(s, method::Delay; master)
 
     # find left and right (virtual) zero padding
     lp = maximum(d)
-    rp = maximum(length(sm) .- (length.(s) .+ d))
-    
+    rp = maximum(lastlength(sm) .- (lastlength.(s) .+ d))
+
     # New window length
     wl = lastlength(sm) - lp - rp
     @assert wl > 0 "Computed window length is negative, this might indicate that the delay computation failed"
-    
+
     # trim individual index sets to fit into new master window
     for i in eachindex(inds)
         start = max(1, 1+lp-d[i])
-        stop = min(length(s[i]),start+wl-1)
+        stop = min(lastlength(s[i]), start+wl-1)
         inds[i] = start : stop
     end
     @assert all(length.(inds) .== length(inds[1]))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -143,4 +143,39 @@ end
         end
     end
 
+    @testset "Shortest master + Indices" begin
+        @info "Testing Shortest master with Indices output"
+
+        timelen(x) = size(x, ndims(x))
+
+        # univariate sanity check
+        for dm in (XcorrDelay(), DTWDelay())
+            method = Delay(delay_method = dm)
+            inds = align_signals(signals_short, method; master = Shortest(), output = Indices())
+            @test all(length.(inds) .== length(inds[1]))
+            aligned = [s[i] for (s, i) in zip(signals_short, inds)]
+            ref = aligned[argmin(timelen.(signals_short))]
+            @test all(norm(a - ref) < (dm isa DTWDelay ? 0.5 : 5.0) for a in aligned)
+        end
+
+        method = Warp(warp_method = DTW(radius = 5))
+        inds = align_signals(signals_short, method; master = Shortest(), output = Indices())
+        @test all(length.(inds) .== length(inds[1]))
+
+        # multivariate signals of unequal length — this is what triggers the bug
+        T  = 0:0.05:4pi
+        base = vcat(sin.(T)', cos.(T)')
+        shifts = [0, 4, 2, 6, 3]
+        trims  = [20, 5, 15, 10, 25]
+        sigs_mv = [base[:, 1+s : end-tr] for (s, tr) in zip(shifts, trims)]
+
+        method = Delay(delay_method = DTWDelay())
+        inds = align_signals(sigs_mv, method; master = Shortest(), output = Indices())
+        @test all(length.(inds) .== length(inds[1]))
+        @test all(maximum(i) <= timelen(s) for (s, i) in zip(sigs_mv, inds))
+        aligned = [s[:, i] for (s, i) in zip(sigs_mv, inds)]
+        ref = aligned[argmin(timelen.(sigs_mv))]
+        @test all(norm(a - ref) < 1e-8 for a in aligned)
+    end
+
 end


### PR DESCRIPTION
## Summary
- `compute_aligning_indices(s, ::Delay; master)` mixed `length` and `lastlength` in the alignment-window math. `length(::Matrix)` is `rows*cols`, not the time dimension, so `rp` and the `stop` upper bound were inflated.
- The bug stayed latent under `Index`/`Longest` masters (non-masters never exceed the master in time) and under univariate vectors (`length == lastlength`). With `master = Shortest()` and matrix signals the returned `inds` could contain values greater than `lastlength(s[i])`, so `signals[i][:, inds[i]]` blew up.
- Fix: use `lastlength` consistently on lines 45 and 54 of `src/methods.jl` and rename the shadowing comprehension variable on line 36.
- Adds a new `@testset "Shortest master + Indices"` covering both univariate and multivariate cases. The decisive multivariate assertion is `maximum(i) <= timelen(s)`.

Closes #2.

## Test plan
- [x] `Pkg.test()` — 44/44 pass
- [x] Multivariate sub-test asserts every returned index is within `lastlength(s)` and that `signals[i][:, inds[i]]` produces aligned outputs across all signals

🤖 Generated with [Claude Code](https://claude.com/claude-code)